### PR TITLE
Update token expiration time to 60 seconds in auth token service

### DIFF
--- a/src/services/auth-token.service.ts
+++ b/src/services/auth-token.service.ts
@@ -14,7 +14,7 @@ export const saveTokenStorage = (accessToken: string) => {
 	Cookies.set(EnumTokens.ACCESS_TOKEN, accessToken, {
 		domain: process.env.NEXT_PUBLIC_DOMAIN,
 		sameSite: 'strict',
-		expires: 1,
+		expires: new Date(new Date().getTime() + 60 * 1000),
 	})
 }
 


### PR DESCRIPTION
Change the expiration time for the access token to enhance security by limiting its validity period.